### PR TITLE
AbstractTrees.printnode() prints basic statistics about the arrary

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -54,6 +54,9 @@ function AbstractTrees.printnode(io::IO, node_value::IMASnodeRepr)
     ids = node_value.ids
     field = node_value.field
     value = node_value.value
+
+    flag_statistics = false
+
     if typeof(value) <: IDS
         printstyled(io, field; bold=true)
     elseif typeof(value) <: IDSvector
@@ -86,6 +89,7 @@ function AbstractTrees.printnode(io::IO, node_value::IMASnodeRepr)
                 end
             else
                 printstyled(io, "$(Base.summary(value))"; color)
+                flag_statistics = true
             end
         else
             color = :purple
@@ -100,6 +104,19 @@ function AbstractTrees.printnode(io::IO, node_value::IMASnodeRepr)
             printstyled(io, " (all $(value[1]))"; color)
         end
 
+        if (flag_statistics)
+            print(io, "\n")
+            print(io, " "^length(string(field) * " ➡ "))
+
+            color = :blue
+
+            printstyled(io, "(min):"; color, bold=true)
+            print(io, @sprintf("%.3g, ", minimum(value)))
+            printstyled(io, "(avg):"; color, bold=true)
+            print(io, @sprintf(":%.3g, ", sum(value) / length(value)))
+            printstyled(io, "(max):"; color, bold=true)
+            print(io, @sprintf("%.3g ", maximum(value)))
+        end
     end
 end
 


### PR DESCRIPTION
## Summary
This PR improves the display of `IDS` data (e.g., `print_tree(dd)`) for array-type data with a length greater than 4. The updated `print_tree` function (along with relevant `Base.show()` methods) now includes basic statistical information (`min`, `avg`, `max`) for arrays, in addition to the previous output.


## Changes
### Existing Feature
`print_tree` previously displayed only a `summary` of a given array (shape & type), and its physical unit if available, as shown below:

![Before_Change](https://github.com/user-attachments/assets/10d2a3a0-1ce6-42f1-8866-86adc382fa50)

### New Feature
The updated `print_tree` now prints basic statistical information (`min`, `avg`, `max`) for arrays, following the previous summary output
Note that it does not affect other data types (e.g., scalar) at all, as shown below.

![After_Change](https://github.com/user-attachments/assets/716f9a24-fff5-4c09-b041-a2ba3484c238)


## Checklist
- [v] Tests passed