### PR TITLE
New feature/ids field finder

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -867,16 +867,12 @@ function _match(@nospecialize(ids::IDSvector), conditions)
     return matches
 end
 
-struct IDS_Field_Finder
+Base.@kwdef struct IDS_Field_Finder
     root_ids::Union{IDS,IDSvector} # Start point of the search
     parent_ids::Union{IDS,IDSvector} # Parent IDS of target field
     field::Symbol # Target field symbol
     field_type::Type # Type of the field
     field_path::String # Relative path from root_ids to the field
-
-    # Named constructor with keyword arguments for clear field assignment
-    IDS_Field_Finder(; root_ids, parent_ids, field, field_type, field_path) =
-        new(root_ids, parent_ids, field, field_type, field_path)
 end
 
 function Base.getproperty(instance::IDS_Field_Finder, prop::Symbol)
@@ -910,7 +906,7 @@ function Base.show(io::IO, ::MIME"text/plain", IFF::IDS_Field_Finder)
 
     unit = units(IFF.parent_ids, IFF.field)
     if !(isempty(unit) || unit == "-")
-        printstyled(io, " [$unit]"; color=:yellow, bold=true)
+        printstyled(io, " [$unit]"; color=:blue, bold=true)
     end
     value = IFF.value
     print(io, " [$(Base.summary(value))]")
@@ -957,7 +953,6 @@ Searches for specified fields within IDS objects, supporting nested field explor
 # Example
 ```julia-repl
 julia> findall(dd.equilibrium.time_slice[].global_quantities) # By default, it searches everything under given IDS
-julia> findall(dd.equilibrium.time_slice[].global_quantities, :all) # Same behavior
 julia> findall(dd.equilibrium.time_slice[].global_quantities, r"") # Same behavior (Default)
 
 # Find fields matching a single symbol within a IDS structure
@@ -982,7 +977,6 @@ julia> IFF[end].value
 ```
 """
 function Base.findall(root_ids_arr::AbstractArray, target_fields::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
-    target_fields == :all ? target_fields = r"" : target_fields
 
     IFF_arr = Vector{IDS_Field_Finder}()
     for root_ids in root_ids_arr
@@ -994,7 +988,6 @@ function Base.findall(root_ids_arr::AbstractArray, target_fields::Union{Symbol,A
 end
 
 function Base.findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
-    target == :all ? target = r"" : target
 
     IFF_list = Vector{IDS_Field_Finder}()
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -901,7 +901,7 @@ function Base.show(io::IO, ::MIME"text/plain", IFF::IDS_Field_Finder)
     rest_part = replace(parent_name, root_name => "")
 
     printstyled(io, root_name; color=:red)
-    if IFF.root_ids isa IMASdd.dd || root_name == parent_name
+    if IFF.root_ids isa DD || root_name == parent_name
         print(io, ".")
     end
     isempty(rest_part) ? nothing : print(io, rest_part * ".")

--- a/src/data.jl
+++ b/src/data.jl
@@ -987,7 +987,7 @@ function Base.findall(root_ids_arr::AbstractArray, target_fields::Union{Symbol,A
     IFF_arr = Vector{IDS_Field_Finder}()
     for root_ids in root_ids_arr
         if root_ids isa Union{IDS,IDSvector}
-            append!(IFF_arr, Base.findall(root_ids, target_fields; include_subfields))
+            append!(IFF_arr, findall(root_ids, target_fields; include_subfields))
         end
     end
     return IFF_arr

--- a/src/data.jl
+++ b/src/data.jl
@@ -942,6 +942,133 @@ function Base.show(io::IO, ::MIME"text/plain", IFF::IDS_Field_Finder)
     end
 end
 
+"""
+    findall(ids::Union{AbstractArray, IDS, IDSvector}, target_fields::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
+Searches for specified fields within IDS objects, supporting nested field exploration and customizable filtering.
+
+# Arguments
+- `root_ids::Union{AbstractArray, IDS, IDSvector}`: Root IDS objects to search.
+- `target_fields::Union{Symbol, AbstractArray{Symbol}, Regex} = r""`: Fields to search for, specified by a single symbol, array of symbols, or regular expression.
+- `include_subfields::Bool = true`: If `true`, retrieves nested fields below the target field when found; if `false`, stops at the matching field.
+
+# Returns
+- `Vector{IDS_Field_Finder}`: A vector of `IDS_Field_Finder` structures, each containing details on a located field such as parent IDS, root IDS, field type, and full field path.
+
+# Example
+```julia-repl
+julia> findall(dd.equilibrium.time_slice[].global_quantities) # By default, it searches everything under given IDS
+julia> findall(dd.equilibrium.time_slice[].global_quantities, :all) # Same behavior
+julia> findall(dd.equilibrium.time_slice[].global_quantities, r"") # Same behavior (Default)
+
+# Find fields matching a single symbol within a IDS structure
+julia> IFF = findall(dd.equilibrium.time_slice, :psi)
+
+# Search for multiple symbols within multiple root IDS objects
+julia> IFF = findall([dd.equilibrium, dd.core_profiles], [:psi, :j_tor])
+
+# Use regular expressions for flexible and powerful search patterns
+julia> IFF = findall(dd, r"prof.*1d.*psi")
+
+# Control subfield inclusion using the `include_subfields` keyword
+julia> IFF = findall(dd, r"prof.*2d"; include_subfields=false)
+julia> IFF = findall(dd, r"prof.*2d"; include_subfields=true) # Default behavior
+
+# Default show for IFF (IDF_Field_Finder) structure
+julia> IFF
+
+# Retrieve actual values of found IDS objects (lazy evaluation)
+julia> IFF[1].value
+julia> IFF[end].value
+```
+"""
+function Base.findall(root_ids_arr::AbstractArray, target_fields::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
+    target_fields == :all ? target_fields = r"" : target_fields
+
+    IFF_arr = Vector{IDS_Field_Finder}()
+    for root_ids in root_ids_arr
+        if root_ids isa Union{IDS,IDSvector}
+            append!(IFF_arr, Base.findall(root_ids, target_fields; include_subfields))
+        end
+    end
+    return IFF_arr
+end
+
+function Base.findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
+    target == :all ? target = r"" : target
+
+    IFF_list = Vector{IDS_Field_Finder}()
+
+    flag_found = false
+    stack = Vector{Tuple{Union{IDS,IDSvector,Vector{IDS}},String,Bool}}()  # Stack initialization
+    sizehint!(stack, 1000)
+
+    if root_ids isa IDSvector
+        parent_ids = (root_ids._parent).value
+        push!(stack, (parent_ids, location(parent_ids), false))
+    else
+        push!(stack, (root_ids, location(root_ids), false))
+    end
+
+    # helper function
+    function is_target_found(ids::Union{IDS,IDSvector}, field::Symbol, path::String, target::Regex)
+        return occursin(target, path)
+    end
+    function is_target_found(ids::Union{IDS,IDSvector}, field::Symbol, path::String, target::Symbol)
+        return field == target
+    end
+    function is_target_found(ids::Union{IDS,IDSvector}, field::Symbol, path::String, target::AbstractArray{Symbol})
+        return field in target
+    end
+
+    while !isempty(stack)
+        ids, path, parent_found = pop!(stack)
+
+        fields = filter(x -> x ∉ IMASdd.private_fields, fieldnames(typeof(ids)))
+
+        for field in fields
+            child = getfield(ids, field)
+
+            isempty(child) ? continue : nothing
+
+            if typeof(child) <: Union{IDSvector,Vector{IDS}}
+                for (k, grand_child) in pairs(child)
+                    new_path = path * "." * String(field) * "[$k]"
+                    flag_found = parent_found ? true : is_target_found(ids, field, new_path, target)
+                    if include_subfields || !flag_found
+                        push!(stack, (grand_child, new_path, flag_found))
+                    end
+                end
+            elseif typeof(child) <: IDS
+                new_path = path * "." * String(field)
+                flag_found = parent_found ? true : is_target_found(ids, field, new_path, target)
+                if include_subfields || !flag_found
+                    push!(stack, (child, new_path, flag_found))
+                end
+            else
+                new_path = path * "." * String(field)
+                flag_found = parent_found ? true : is_target_found(ids, field, new_path, target)
+            end
+
+            if flag_found
+                if !ismissing(ids, field)
+                    push!(IFF_list,
+                        IDS_Field_Finder(;
+                            parent_ids=ids,
+                            root_ids=root_ids,
+                            field=field,
+                            field_type=fieldtype(typeof(ids), field),
+                            field_path=new_path)
+                    )
+                end
+                flag_found = false
+            end
+        end
+    end
+
+    # Considering that stack is (Last-In, First-Out),
+    # reverse the IFF_list to make it is in the order of given input
+    return reverse!(IFF_list)
+end
 
 #= ==== =#
 #  keys  #


### PR DESCRIPTION
## Summary
This PR introduces a new `findall` method that searches for specific fields within multiple `IDS` objects.
The target fields can be specified using either Symbols or Regex patterns.
The `findall` method returns an IDS_Field_Finder struct for each matched field, containing detailed information that allows for verbose terminal output and plot recipes.

Note: The plot `@recipes` will be represnted in another PR soon.

## Examples
Here are some quick examples.

### 1. Default behavior
```julia
# By default, it searches everything under the given IDS
# Following commands produce the same result
findall(dd.equilibrium.time_slice[].global_quantities)
findall(dd.equilibrium.time_slice[].global_quantities, r"") # Same behavior (Default)
findall(dd.equilibrium.time_slice[].global_quantities, :all) # Same behavior
```
<img src="https://github.com/user-attachments/assets/9fb762a4-9ca0-4ba9-875c-2da150d74c1c" width=80%>


### 2. Finding a single field within a single root IDS
```julia
 # Find fields matching a single symbol within a IDS structure
IFF = findall(dd.equilibrium.time_slice, :psi)
```
<img src="https://github.com/user-attachments/assets/4419bccc-89d0-4094-bc10-48544d54619e" width=80%>

### 3. Finding multiple fields within multiple root IDS objects
```julia
 # Search for multiple symbols within multiple root IDS objects
IFF = findall([dd.equilibrium, dd.core_sources], [:psi, :j_tor])
```
<img src="https://github.com/user-attachments/assets/135f080d-6e08-4daf-b25f-7159cd898b8f" width=80%>

### 4. Keyword argument of `include_subfields::Bool=true` 
```julia
  # Control subfield inclusion using the `include_subfields` keyword
IFF = findall(dd, r"prof.*2d"; include_subfields=false)
IFF = findall(dd, r"prof.*2d"; include_subfields=true) # Default behavior
```
<img src="https://github.com/user-attachments/assets/4415a1db-43c5-42a3-9dc5-0fdcfb24697e" width=80%>

### 5. Lazy evaluation of the value of found field objects

```julia
 # Retrieve actual values of found field objects (lazy evaluation)
IFF[1].value
IFF[end].value
```
<img src="https://github.com/user-attachments/assets/cc18f597-2151-4346-9fab-a588b6c2175b" width=50%>
