### PR TITLE
Improve dict2imas & isequal

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -111,7 +111,7 @@ function dict2imas(dct::AbstractDict, @nospecialize(ids::T); error_on_missing_co
     return ids
 end
 
-function dict2imas(
+function dict2imas_original(
     dct::AbstractDict,
     @nospecialize(ids::T),
     path::Vector{<:AbstractString};
@@ -199,6 +199,7 @@ function dict2imas(
 end
 
 export dict2imas
+export dict2imas_original
 push!(document[:IO], :dict2imas)
 
 """

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -11,31 +11,35 @@ include(joinpath(@__DIR__, "test_expressions_dicts.jl"))
     filename = joinpath(dirname(@__DIR__), "sample", "omas_sample.json")
     ddj = IMAS.json2imas(filename)
 
-    @test isempty(diff(ddj, ddh))
-
+    # @test isempty(diff(ddj, ddh))
+    @test ddj == ddh
     test_dir = mktempdir()
 
     @testset "JSON_strict" begin
         IMAS.imas2json(ddj, joinpath(test_dir, "test.json"); strict=true, freeze=false)
         dd = IMAS.json2imas(joinpath(test_dir, "test.json"))
-        @test isempty(diff(ddj, dd))
+        # @test isempty(diff(ddj, dd))
+        @test ddj==dd
     end
 
     @testset "JSON_strict_frozen" begin
         IMAS.imas2json(ddj, joinpath(test_dir, "test.json"); strict=true, freeze=true)
         dd = IMAS.json2imas(joinpath(test_dir, "test.json"))
-        @test isempty(diff(IMAS.freeze(ddj), IMAS.freeze(dd)))
+        # @test isempty(diff(IMAS.freeze(ddj), IMAS.freeze(dd)))
+        @test IMAS.freeze(ddj) == IMAS.freeze(dd)
     end
 
     @testset "JSON" begin
         IMAS.imas2json(ddj, joinpath(test_dir, "test.json"); strict=false, freeze=false)
         dd = IMAS.json2imas(joinpath(test_dir, "test.json"))
-        @test isempty(diff(ddj, dd))
+        # @test isempty(diff(ddj, dd))
+        @test ddj == dd
     end
 
     @testset "HDF" begin
         IMAS.imas2hdf(ddh, joinpath(test_dir, "test.hdf"); strict=false, freeze=false)
         dd = IMAS.hdf2imas(joinpath(test_dir, "test.hdf"))
-        @test isempty(diff(ddh, dd))
+        # @test isempty(diff(ddh, dd))
+        @test ddh == dd
     end
 end

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -11,35 +11,30 @@ include(joinpath(@__DIR__, "test_expressions_dicts.jl"))
     filename = joinpath(dirname(@__DIR__), "sample", "omas_sample.json")
     ddj = IMAS.json2imas(filename)
 
-    # @test isempty(diff(ddj, ddh))
     @test ddj == ddh
     test_dir = mktempdir()
 
     @testset "JSON_strict" begin
         IMAS.imas2json(ddj, joinpath(test_dir, "test.json"); strict=true, freeze=false)
         dd = IMAS.json2imas(joinpath(test_dir, "test.json"))
-        # @test isempty(diff(ddj, dd))
         @test ddj==dd
     end
 
     @testset "JSON_strict_frozen" begin
         IMAS.imas2json(ddj, joinpath(test_dir, "test.json"); strict=true, freeze=true)
         dd = IMAS.json2imas(joinpath(test_dir, "test.json"))
-        # @test isempty(diff(IMAS.freeze(ddj), IMAS.freeze(dd)))
         @test IMAS.freeze(ddj) == IMAS.freeze(dd)
     end
 
     @testset "JSON" begin
         IMAS.imas2json(ddj, joinpath(test_dir, "test.json"); strict=false, freeze=false)
         dd = IMAS.json2imas(joinpath(test_dir, "test.json"))
-        # @test isempty(diff(ddj, dd))
         @test ddj == dd
     end
 
     @testset "HDF" begin
         IMAS.imas2hdf(ddh, joinpath(test_dir, "test.hdf"); strict=false, freeze=false)
         dd = IMAS.hdf2imas(joinpath(test_dir, "test.hdf"))
-        # @test isempty(diff(ddh, dd))
         @test ddh == dd
     end
 end


### PR DESCRIPTION
## Summary
This PR introduces new `dict2imas` and `isequal` methods, where the original counterpart methods are quite slow at the first call due to the long compilation time.

In particular, `diff(dd1,dd2)` is extremely slow at the first-call (takes more than 1 hour).
The new `isequal(dd1,dd2)` or equivalent `dd1==dd2` is greatly faster at the first-call (takes only 0.27 secs).
In addition, the new method with flag, i.e. `isequal(dd1,dd2; verbose=true)`, can provide more verbose comprehensive information about the differences between two IDS objects.

The followings are quick performance comparisons:

### 1. `dict2imas` performance comparison
The new `dict2imas` is about twice faster at the first-call.
- Original `dict2imas` for `sample/omas_sample.json`
    - first-call (with compilation): ~ 20 seconds
    - after that: ~ 17 ms
- New `dict2imas` for `sample/omas_sample.json`
    - first-call (with compilation): ~ 10 seconds
    - after that: ~ 17 ms

### 2. `diff` vs `isequal` performance comparison
The new `isequal` is more than 10,000 times faster a the first call.
- `diff(dd1, dd2)`
    - first-call (with compilation): > 3600 seconds (≈ 1 hour)
    - after that: ~ 40 ms
- `isequal(dd1, dd2)` or `dd1 == dd2`
    - first-call: (with compilation): ~ 0.27 seconds
    - after that: ~ 8.5 ms


## Current feature
```julia
# First call
@time dd1 = json2imas("sample/omas_sample.json")
```
![Screenshot 2024-11-12 at 9 48 06 AM](https://github.com/user-attachments/assets/dc999e52-0d9e-48f3-8afe-4b58db1935c6)

```julia
# Benchmark after the first call
@benchmark dd2 = json2imas("sample/omas_sample.json")
```
![Screenshot 2024-11-12 at 9 49 55 AM](https://github.com/user-attachments/assets/39d433f1-239f-42f0-b293-61cf9517ea2e)

```julia
@time diff(dd1, dd2) # Note: This will take more than 1 hour
```
Note that the number of allocations for the first-call of `diff` is huge (~ 1.75 G allocations), which makes it extremely slow.
![Screenshot 2024-11-12 at 9 01 54 AM](https://github.com/user-attachments/assets/0fcf193f-dcc4-4737-9a77-8b8559845a17)

```julia
# Modify dd2 to compare it with dd1
dd2.equilibrium.time_slice[1].profiles_1d.volume=[1.0,2,3];
dd2.equilibrium.time_slice[1].profiles_1d.psi[[1,7,8,13,15]].= rand(5);
dd2.equilibrium.time_slice[1].profiles_2d[1].psi .= 0.0;
dd2.core_sources.source[1].identifier.name="abcde"
 
diff(dd1, dd2) 
```
`diff` briefly shows the differences.
![Screenshot 2024-11-12 at 9 01 36 AM](https://github.com/user-attachments/assets/433cf871-5c05-453c-8d28-b1fde38b3799)


## New feature
```julia
# First call
@time dd1 = json2imas("sample/omas_sample.json")
```
![Screenshot 2024-11-12 at 10 55 17 AM](https://github.com/user-attachments/assets/47030a6b-b7c3-48c9-94ba-dc7928958bf9)

```julia
# Benchmark after the first call
@benchmark dd2 = json2imas("sample/omas_sample.json")
```
![Screenshot 2024-11-12 at 10 55 46 AM](https://github.com/user-attachments/assets/235e9b98-b14a-4eb2-a563-e949beec6ed6)


```julia
# First call
@time isequal(dd1, dd2)
```
![Screenshot 2024-11-12 at 10 56 19 AM](https://github.com/user-attachments/assets/5ef52e56-0ec0-44e2-997e-e165804fac35)

```julia
# Modify dd2 to compare it with dd1
dd2.equilibrium.time_slice[1].profiles_1d.volume=[1.0,2,3];
dd2.equilibrium.time_slice[1].profiles_1d.psi[[1,7,8,13,15]].= rand(5);
dd2.equilibrium.time_slice[1].profiles_2d[1].psi .= 0.0;
dd2.core_sources.source[1].identifier.name="abcde"

isequal(dd1, dd2; verbose=true)
```
![Screenshot 2024-11-12 at 10 38 05 AM](https://github.com/user-attachments/assets/c652c2a8-1b3c-4bda-b291-418a87d07d3d)



## Notes
[v] all tests passed
