### PR TITLE
`@findall` macro for multiple IDS objects

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -958,6 +958,9 @@ julia> findall(dd.equilibrium.time_slice[].global_quantities, r"") # Same behavi
 # Find fields matching a single symbol within a IDS structure
 julia> IFF = findall(dd.equilibrium.time_slice, :psi)
 
+# Search for multiple symbols within multiple root IDS objects
+julia> IFF = findall([dd.equilibrium, dd.core_profiles], [:psi, :j_tor])
+
 # Use regular expressions for flexible and powerful search patterns
 julia> IFF = findall(dd, r"prof.*1d.*psi")
 
@@ -973,6 +976,17 @@ julia> IFF[1].value
 julia> IFF[end].value
 ```
 """
+function Base.findall(root_ids_arr::AbstractArray, target_fields::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
+
+    IFF_arr = Vector{IDS_Field_Finder}()
+    for root_ids in root_ids_arr
+        if root_ids isa Union{IDS,IDSvector}
+            append!(IFF_arr, findall(root_ids, target_fields; include_subfields))
+        end
+    end
+    return IFF_arr
+end
+
 function Base.findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
 
     IFF_list = Vector{IDS_Field_Finder}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,3 +7,5 @@ include("runtests_time.jl")
 include("runtests_itp.jl")
 
 include("runtests_io.jl")
+
+include("runtests_findall.jl")

--- a/test/runtests_findall.jl
+++ b/test/runtests_findall.jl
@@ -1,0 +1,29 @@
+using IMASdd
+import IMASdd as IMAS
+using Test
+
+include(joinpath(@__DIR__, "test_expressions_dicts.jl"))
+
+@testset "findall" begin
+
+    filename = joinpath(dirname(@__DIR__), "sample", "omas_sample.json")
+    dd_json = IMAS.json2imas(filename)
+
+    # Basic test
+    IFF = findall(dd_json, r"psi")
+    @test IFF[1].root_name == "dd"
+    @test IFF[1].field_path == "dd.core_profiles.profiles_1d[1].grid.psi"
+    @test IFF[1].value[1] ≈ -2.2834845617831316
+
+
+    # custom root name
+    IFF = findall(dd_json,r"prof.*1d.*psi$"; root_name = "This is my custrom root_name")
+    @test IFF[1].root_name == "This is my custrom root_name"
+
+
+    # macro test
+    eqt = dd_json.equilibrium.time_slice[]
+
+    @test findall(eqt, :psi)[1].field_path == "equilibrium.time_slice[1].profiles_1d.psi"
+    @test (@findall eqt  :psi)[1].field_path == "eqt.profiles_1d.psi"
+end


### PR DESCRIPTION
# Summary
The previous `findall` method for multiple IDS objects is removed due to the ambiguous type inferences.
Instead, a new `@findall` macro handles multiple IDS objects by calling the `findall` function for a single IDS object.
The macro captures the input argument's names and passes them into a new keyword argument of the `root_name` of the `findall` function.
This is beneficial for distinguishing different IDS objects more clearly as shown in below.


# Existing feature
Existing `findall` cannot distinguish different IDS objects as it set the root_name by using the `location` function.
Suppose we have multiple different `dd` data, such as `dd_D3D` and `dd_FPP`.

```julia
# The results look the same
findall(dd_D3D, :label)
findall(dd_FPP, :label)
```
![Screenshot 2024-11-14 at 2 30 39 PM](https://github.com/user-attachments/assets/ed11355f-ed55-4afc-a8a8-5c7840d47fdc)

```julia
# findall results cannot capture the given variable names
eqt_D3D = dd_D3D.equilibrium.time_slice[]
eqt_FPP = dd_FPP.equilibrium.time_slice[]
findall(eqt_D3D, :psi)
findall(eqt_FPP, :psi)
```
![Screenshot 2024-11-14 at 2 30 50 PM](https://github.com/user-attachments/assets/65e64470-6588-4bbb-bfb0-620ebada5e86)


# New feature
```julia
eqt_D3D = dd_D3D.equilibrium.time_slice[]
# One can specify the `root_name` as the keyword argument
findall(eqt_D3D, :psi; root_name="eqt_D3D")
```
![Screenshot 2024-11-14 at 2 33 15 PM](https://github.com/user-attachments/assets/d328bcf2-c22d-43b2-849c-f22c6ce877a1)

```julia
# @findall macro can handle multiple IDS objects,
# and use given variable names as root_names
@findall [dd_D3D, dd_FPP] :label
```
![Screenshot 2024-11-14 at 2 35 19 PM](https://github.com/user-attachments/assets/63220474-9d57-479f-83cc-4e5a42c30af9)

```julia
@findall [ dd_FPP, eqt_D3D] r"prof.*1d.*psi$"
```
![Screenshot 2024-11-14 at 2 37 09 PM](https://github.com/user-attachments/assets/5e905076-aa07-4bb9-ae4a-147d4f682e05)



# Note
New testset for "findall" is implemented.
[v] All tests passed


