### PR TITLE
Improve/json2imas

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -436,7 +436,8 @@ Like setfield! but also add to list of filled fields
 
 NOTE: setraw! does not set the parent. Only setproperty! does that.
 """
-function setraw!(@nospecialize(ids::IDS{T}), field::Symbol, v::Any) where {T<:Real}
+function setraw!(@nospecialize(ids::IDS), field::Symbol, v::Any)
+    T = eltype(ids)
     if field in private_fields
         error("Use `setfield!(ids, :$field, ...)` instead of setraw!(ids, :$field ...)")
     end


### PR DESCRIPTION
# Summary
This PR improves the performance of the `first-call` of `json2imas` or `dict2imas` functions.

Following is the summarized changes:

- Preallocate `Vector` of the required size instead of using `resize!` in `dict2imas` and `push!` in `coordinates` functions
- For `coordinates` and `setraw!` methods, the type of given IDS object is now deteremined during the run-time to avoid the expensive Type-inference at compilation 
- Reduce allocations from unnecessary repeated calls of `WeakRef(ids)` for setting `:_parent` in `dd.jl`. As this change has no big impact on the performance, you may ignore this change (the last commit).

# Performance comparison 
I've tested `json2imas` function for reading `sample/omas_sample.json` in IMASdd folder.

## Fisrt call (with compilation)
| IMASdd version              | Elapsed time  |  allocations |
| :------: | :------: | :----: |
| 2.4.4       |   ~ 19 secs   | 91.39 M allocations (4.618 GiB) |
| 2.4.7           |   ~ 10 secs   | 50.71 M allocations (2.557 GiB) |
| This PR    |  ~ 5.5 secs   | 29.13 M allocations (1.474 GiB) |


## After compilation (@benchmark result)
| IMASdd version              | Elapsed time  |  allocations |
| :------: | :------: | :----: |
| 2.4.4       |   ~ 17.048 $\pm$ 1.464 ms   | 71249 allocations (3.66 MiB) |
| 2.4.7           |  ~ 17.270 $\pm$ 1.235 ms   | 78064 allocations (3.91 MiB) |
| This PR    |  ~ 17.277 $\pm$ 1.152 ms   | 71721 allocations (3.67 MiB) |
