### PR TITLE
Minor updates and fixes regarding `IDS_Field_Finder`

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -890,7 +890,8 @@ function Base.getproperty(instance::IDS_Field_Finder, prop::Symbol)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", IFF_list::AbstractArray{IDS_Field_Finder})
-    for IFF in IFF_list
+    for (k, IFF) in pairs(IFF_list)
+        printstyled(io, "[$k] "; color=:lightblack)
         show(io, MIME"text/plain"(), IFF)
         print(io, "\n")
     end
@@ -899,12 +900,14 @@ end
 function Base.show(io::IO, ::MIME"text/plain", IFF::IDS_Field_Finder)
     root_name = IFF.root_name
     rest_part = replace(IFF.field_path, root_name => "")
+    rest_part = replace(rest_part, String(IFF.field) => "")
 
     parent_name = location(IFF.parent_ids)
 
     printstyled(io, root_name; color=:red)
 
-    isempty(rest_part) ? nothing : print(io, rest_part * ".")
+    # isempty(rest_part) ? nothing : print(io, rest_part * ".")
+    print(io, rest_part)
 
     printstyled(io, String(IFF.field); color=:green, bold=true)
 
@@ -1121,7 +1124,11 @@ function Base.findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,Abstr
 
     # Considering that stack is (Last-In, First-Out),
     # reverse the IFF_list to make it is in the order of given input
-    return reverse!(IFF_list)
+    if length(IFF_list) == 1
+        return IFF_list[1]
+    else
+        return reverse!(IFF_list)
+    end
 end
 
 #= ==== =#

--- a/src/data.jl
+++ b/src/data.jl
@@ -952,7 +952,7 @@ end
     @findall [ids1, ids2] r"Regular Expression"
 Searches for specified fields within single/multiple IDS objects, while capturing their names into IDS_Field_Finder.root_name
 
-See also [`findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,AbstractArray{Symbol},Regex}=r"; kwargs)`](@ref) which this macro calls after expansion.
+See also [`findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,AbstractArray{Symbol},Regex}=r""; kwargs)`](@ref) which this macro calls after expansion.
 
 
 # Arguments
@@ -967,7 +967,6 @@ See also [`findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,Abstract
 julia> @findall [dd1, dd2] [:psi,:j_tor]
 julia> @findall [dd1, dd2] r"psi"
 
-julia> eqt = dd.equilibrium.time_slice[]
 julia> eqt = dd.equilibrium.time_slice[]
 
 julia> @findall eqt :psi
@@ -1012,11 +1011,11 @@ export @findall
 push!(document[:Base], Symbol("@findall"))
 
 """
-    findall(ids::Union{AbstractArray, IDS, IDSvector}, target_fields::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
+    findall(ids::Union{IDS, IDSvector}, target_fields::Union{Symbol,AbstractArray{Symbol},Regex}=r""; include_subfields::Bool=true)
 Searches for specified fields within IDS objects, supporting nested field exploration and customizable filtering.
 
 # Arguments
-- `root_ids::Union{AbstractArray, IDS, IDSvector}`: Root IDS objects to search.
+- `root_ids::Union{IDS, IDSvector}`: Root IDS objects to search.
 - `target_fields::Union{Symbol, AbstractArray{Symbol}, Regex} = r""`: Fields to search for, specified by a single symbol, array of symbols, or regular expression.
 - `include_subfields::Bool = true`: If `true`, retrieves nested fields below the target field when found; if `false`, stops at the matching field.
 
@@ -1130,6 +1129,8 @@ function Base.findall(root_ids::Union{IDS,IDSvector}, target::Union{Symbol,Abstr
         return reverse!(IFF_list)
     end
 end
+
+push!(document[:Base], :findall)
 
 #= ==== =#
 #  keys  #

--- a/src/data.jl
+++ b/src/data.jl
@@ -906,7 +906,6 @@ function Base.show(io::IO, ::MIME"text/plain", IFF::IDS_Field_Finder)
 
     printstyled(io, root_name; color=:red)
 
-    # isempty(rest_part) ? nothing : print(io, rest_part * ".")
     print(io, rest_part)
 
     printstyled(io, String(IFF.field); color=:green, bold=true)

--- a/src/io.jl
+++ b/src/io.jl
@@ -270,8 +270,11 @@ function Base.isequal(a::T1, b::T2; verbose::Bool=false) where {T1<:Union{IDS,ID
             continue
         end
 
-        # Iterate over all fields in the object
-        for field in fieldnames(typeof(obj_a))
+        # Get target_fields in obj_a, excluding private_fields
+        target_fields = filter(x -> x ∉ IMASdd.private_fields, fieldnames(typeof(obj_a)))
+
+        # Iterate over target_fields in the object
+        for field in target_fields
             field_a = getfield(obj_a, field)
             field_b = getfield(obj_b, field)
 


### PR DESCRIPTION
# Summary

This PR addresses three key issues:

1. Exclude private_fields when running `isequal` function
2. Fixes a parsing error in the docstring of the `findall` method**, ensuring successful documentation generation.
3. Enhances the `Base.show()` method for the `IDS_Field_Finder` structure**, resolving a display bug and improving usability.

# Changes

## 1 . Exclude private_fields in `isequal`
- By this fix, `dd1==dd2` or `isequal(dd1,dd2)` does not compare private fields (such as :_aux), only the actual data.

## 2. Fix Parsing Error in `findall` Docstring

- **Issue**: A missing double-quote (`"`) in the docstring of the `findall` method caused the Documenter to fail, preventing successful documentation generation.
- **Resolution**: Added the missing double-quote to the docstring, and updated some of the examples.
- **Outcome**: The documentation is now generated successfully without errors.

## 3. Update `Base.show()` for `IDS_Field_Finder` Structure

### Before

- **Bug**: The last field (e.g., `psi` in the following screenshot) was displayed twice
  
  ![Before Fix](https://github.com/user-attachments/assets/f651e78d-99b7-4442-ac86-46c6f45cf858)

### After

- **Bug Fix**: Removed the duplicate display of the `psi` field.
- **Enhancement**: Modified the display format to show the index first, facilitating quicker identification and usage of specific fields within the IFF 

  ![After Fix](https://github.com/user-attachments/assets/61a5fb18-62ff-4f1a-b68b-6051909eb452)
