### PR TITLE
Explain the expression when `FLAG_EXPLAIN_EXPRESSION[]=true`

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -4,6 +4,8 @@ import OrderedCollections
 import StaticArraysCore
 document[:Base] = Symbol[]
 
+const FLAG_EXPLAIN_EXPRESSION = Ref(false)
+
 #= ============================ =#
 #  IDS and IDSvector structures  #
 #= ============================ =#
@@ -398,10 +400,27 @@ function _getproperty(@nospecialize(ids::IDS), field::Symbol)
 
     elseif !isfrozen(ids)
         # expressions
+        if FLAG_EXPLAIN_EXPRESSION[]
+            expr_info_dict = get_expr_info_dict(Val{:onetime_and_dynamic})
+        end
         uloc = ulocation(ids, field)
         for (onetime, expressions) in zip((true, false), (get_expressions(Val{:onetime}), get_expressions(Val{:dynamic})))
             if uloc ∈ keys(expressions)
                 func = expressions[uloc]
+
+                if FLAG_EXPLAIN_EXPRESSION[]
+                    show(stdout, "text/plain", expr_info_dict[uloc])
+
+                    # To get the result of this expression, turning off the FLAG temporarily
+                    FLAG_EXPLAIN_EXPRESSION[] = false
+                    value = exec_expression_with_ancestor_args(ids, field, func)
+                    FLAG_EXPLAIN_EXPRESSION[] = true
+
+                    # Display the result
+                    printstyled("[Result]\n"; color=:blue)
+                    display(value)
+                    print("\n")
+                end
                 value = exec_expression_with_ancestor_args(ids, field, func)
                 if typeof(value) <: Exception
                     # check in the reference

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -18,6 +18,11 @@ function get_expressions(::Type{Val{T}}) where {T}
     return Dict{String,Function}()
 end
 
+function get_expr_info_dict(::Type{Val{T}}) where {T}
+    # This is just a place holder, the actual second argument will be "ExprInfo" struct defined in IMAS
+    return Dict{String,Any}()
+end
+
 const expression_onetime_weakref = Dict{UInt64,WeakRef}()
 
 """


### PR DESCRIPTION
## Summary
This PR is to "explain" the detailed procedures when executing `onetime` or `dynamic` expressions in dd, which is to address the issue raised from the code camp (see `Backend/user interace` section in https://github.com/ProjectTorreyPines/FUSE.jl/issues/786).

The more details and examples are described in the following PR:
(FUSE PR)

## **Dependency / Related PRs**
This change depends on related PR in the `IMAS` package to fully function. 

## Note
- CI might fail until dependent PRs are merged.
- Once the dependent changes are integrated, this PR should work as expected.