### PR TITLE
Bugfix/isequal ids

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -244,9 +244,13 @@ function Base.isequal(a::T1, b::T2; verbose::Bool=false) where {T1<:Union{IDS,ID
     stack = Vector{Tuple{Any,Any,String}}()
 
     if a isa IDSvector
-        a_parent_ids = (a._parent).value
-        b_parent_ids = (b._parent).value
-        push!(stack, (a_parent_ids, b_parent_ids, location(a_parent_ids)))
+        if length(a) != length(b)
+            verbose ? highlight_differences(location(a), a, b) : nothing
+            return false
+        end
+        for i in eachindex(a)
+            push!(stack, (a[i], b[i], location(a[i])))
+        end
     else
         push!(stack, (a, b, location(a)))
     end

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -38,3 +38,23 @@ include(joinpath(@__DIR__, "test_expressions_dicts.jl"))
         @test ddh == dd
     end
 end
+
+@testset "isequal" begin
+    filename = joinpath(dirname(@__DIR__), "sample", "omas_sample.h5")
+    dd1 = IMAS.hdf2imas(filename)
+    dd2 = IMAS.hdf2imas(filename)
+
+    @test dd1 == dd2
+    @test dd1.core_sources == dd2.core_sources
+
+    dd2.core_sources.time[] = 1.0
+    @test !isequal(dd1, dd2)
+    @test !isequal(dd1.core_sources, dd2.core_sources)
+    @test isequal(dd1.core_sources.source, dd2.core_sources.source)
+
+    resize!(dd2.core_sources.source,5)
+    @test !isequal(dd1.core_sources.source, dd2.core_sources.source)
+
+    dd2.core_sources.source[2].identifier.index=0
+    @test (dd1.core_sources.source[1:3].==dd2.core_sources.source[1:3]) == BitVector([1,0,1])
+end


### PR DESCRIPTION
## Issue
`isequal` exhibits a bug when comparing IDSvector inputs.

## Bug Fix
- Fixed the bug in `isequal` for IDSvector data.
- Added new tests for `isequal` to verify correct behavior.

## Note
This fix is merge-safe and does not affect any other functionality.