### PR TITLE
Add Compression Support to imas2hdf

### DIFF
--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -41,6 +41,18 @@ include(joinpath(@__DIR__, "test_expressions_dicts.jl"))
         IMAS.imas2hdf(ddh, joinpath(test_dir, "test.hdf"); strict=false, freeze=false)
         dd = IMAS.hdf2imas(joinpath(test_dir, "test.hdf"))
         @test ddh == dd
+
+        # compression test (compression level is from 0 (no compresson) to 9)
+        IMAS.imas2hdf(ddh, joinpath(test_dir, "test_comp.hdf"); strict=false, freeze=false, compress=9)
+        dd_comp = IMAS.hdf2imas(joinpath(test_dir, "test_comp.hdf"))
+        @test ddh == dd_comp
+
+        # Compare file sizes
+        uncompressed_size = stat(joinpath(test_dir, "test.hdf")).size
+        compressed_size   = stat(joinpath(test_dir, "test_comp.hdf")).size
+        @info "Uncompressed file size: $uncompressed_size bytes"
+        @info "Compressed file size: $compressed_size bytes"
+        @test compressed_size < uncompressed_size
     end
 end
 


### PR DESCRIPTION
## Summary

- Added a `compress` keyword (integer 0–9) to `imas2hdf` for compression of array data.
  - compression level: 0 (no compression) to 9 (highest compression)
- New tests to verify that a compressed file (e.g. with `compress=9`) produces the same data as an uncompressed file, and that the physical file size is reduced.

## Example Usage

```julia
# Uncompressed file
IMAS.imas2hdf(dd, "test.h5");

# Compressed file
IMAS.imas2hdf(dd, "test_compressed.h5"); compress=9)
```

## Compression efficiency
- minor impact for small cases (e.g., `sample/omas_sample.h5`)
  -  1.32 Mb ➡︎1.26 Mb ( about 5 % compression)
- Some impact for larger cases (e.g., one of test cases on Omega)
  -  4.7 Mb ➡︎ 3.7 Mb ( about 20 % compression) 


