### PR TITLE
Improve the flexibility of `h5merge` with new keywords

### DIFF
--- a/test/runtests_io_extended.jl
+++ b/test/runtests_io_extended.jl
@@ -96,6 +96,10 @@ include(joinpath(@__DIR__,"test_expressions_dicts.jl"))
         @test keys(fid) == ["11.h5", "22.h5", "aa.h5", "bb.h5"]
         close(fid)
 
+        # h5_strip_group_prefix test
+        h5merge(combined_file_name, [tmp_dir1, tmp_dir2]; mode="w", pattern=r".*h5", verbose=true, h5_strip_group_prefix=true, skip_existing_entries=true)
+        h5merge(combined_file_name, [tmp_dir1, tmp_dir2]; mode="w", pattern=r".*h5", verbose=true, h5_strip_group_prefix=true, skip_existing_entries=false)
+
         # Merge including non-hdf5 files (txt and binaryfile)
         touch(joinpath(tmp_dir1,"empty.txt"))
         open(joinpath(tmp_dir1, "test.txt"), "w") do f


### PR DESCRIPTION
## Summary
- Improve `h5merge`'s flexibility by adding two new keywords.
- These changes are required as a foundation for future PR (see `#placeholder`) which will allow `DataBaseGenerator` and `MultiObjectiveOptimizer` to their output into a single merged hdf5 file. 

## Description

This PR updates the `h5merge` function to allow more flexible merging of HDF5 files by introducing two new keyword arguments:

- **`h5_group_search_depth`**: Specifies the depth at which to collect group paths from the input HDF5 file.
  - `0` means to consider the root (`"/"`).
  - `1` collects immediate children of the root.
  - Higher values collect groups deeper in the hierarchy.
  
- **`h5_strip_group_prefix`**: A boolean flag indicating whether to omit the parent group name (i.e. the key from `keys_files`) when constructing the target path in the output file.
  - If `false` (default), the parent's name is prepended to the copied group paths.
  - If `true`, the parent's name is omitted, so the copied group paths start directly with the children.

## Testing
- New tests have been added in `test/runtests_io_extended.jl` to verify the behavior of the new keywords.
