### PR TITLE
dd with abstract types

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -271,7 +271,6 @@ function Base.getproperty(ids::IDS, field::Symbol; to_cocos::Int=user_cocos)
     return value
 end
 
-
 """
     getproperty(ids::IDS, field::Symbol, default::Any; to_cocos::Int=user_cocos)
 
@@ -303,6 +302,25 @@ function Base.getproperty(ids::IDS, field::Symbol, default::Any; to_cocos::Int=u
         cocos_out(ids, field, value, to_cocos)
     else
         return default
+    end
+end
+
+"""
+    getproperty(ids::Union{IDS_grid_ggd{T},IDSvectorTimeElement_grid_ggd{T},IDSvectorElement_grid_ggd}, field::Symbol) where {T<:Real}
+
+This function links all grid_ggd types with each other
+
+If the grid_ggd has a path defined to another instance of grid_ggd, this instance would automatically return attributed from the referred instance.
+"""
+function Base.getproperty(ids::Union{IDS_grid_ggd{T},IDSvectorTimeElement_grid_ggd{T},IDSvectorElement_grid_ggd}, field::Symbol) where {T<:Real}
+    if field == :path
+        return getfield(ids, field)
+    else
+        ref_ids_name = Symbol(split(ids.path, "/")[1])
+        grid_ggd_ind = parse(Int64, split(split(ids.path, "(")[2], ")")[1])
+        ref_ids = getfield(top_dd(ids), ref_ids_name)
+        grid_ggd = getfield(ref_ids, :grid_ggd)
+        return getfield(grid_ggd[grid_ggd_ind], field)
     end
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -271,14 +271,6 @@ function Base.getproperty(ids::IDS, field::Symbol; to_cocos::Int=user_cocos)
     return value
 end
 
-"""
-    Base.getproperty(ids::Union{IDSraw, IDSvectorRawElement}, field::Symbol)
-
-No processing for IDSraw and IDSvectorRawElement
-"""
-@inline function Base.getproperty(ids::Union{IDSraw,IDSvectorRawElement}, field::Symbol)
-    return getfield(ids, field)
-end
 
 """
     getproperty(ids::IDS, field::Symbol, default::Any; to_cocos::Int=user_cocos)

--- a/src/data_header.jl
+++ b/src/data_header.jl
@@ -7,15 +7,7 @@ abstract type DD{T} <: IDS{T} end
 
 abstract type IDStop{T} <: IDS{T} end
 
-abstract type IDSraw{T} <: IDS{T} end
-
 abstract type IDSvectorElement{T} <: IDS{T} end
-
-abstract type IDSvectorRawElement{T} <: IDSvectorElement{T} end
-
-abstract type IDSvectorIonElement{T} <: IDSvectorElement{T} end
-
-abstract type IDSvectorStaticElement{T} <: IDSvectorElement{T} end
 
 abstract type IDSvectorTimeElement{T} <: IDSvectorElement{T} end
 

--- a/src/identifiers.jl
+++ b/src/identifiers.jl
@@ -387,7 +387,7 @@ function Base.getindex(ids::IDSvector, identifier_name::Symbol)
     end
 end
 
-function Base.getindex(ids::IDSvector{T}, identifier_name::Symbol) where {T<:IDSvectorIonElement}
+function Base.getindex(ids::IDSvector{T}, identifier_name::Symbol) where {T<:IDSvectorElement_ion}
     available_ions = Symbol[]
     for ion in ids
         if Symbol(ion.label) == identifier_name

--- a/src/show.jl
+++ b/src/show.jl
@@ -22,7 +22,7 @@ function AbstractTrees.children(node_value::IMASnodeRepr)
     if typeof(value) <: IDS
         ns = NoSpecialize(value)
         return (IMASnodeRepr(ns.value, field, getraw(ns.value, field)) for field in keys_no_missing(ns.value))
-    elseif typeof(value) <: IDSvector && eltype(value) <: IDSvectorRawElement
+    elseif typeof(value) <: IDSvector && eltype(value) <: Union{IDSvectorElement_ggd,IDSvectorTimeElement_ggd}
         n = 5
         if length(value) > n * 3
             return [[value[k] for k in 1:n]; Val(:...); [value[k] for k in length(value)-n:length(value)]]


### PR DESCRIPTION
@anchal-physics please give this a try. In the end I settled for keeping the concrete types unchanged and just rationalized how the abstract types are defined throughout the dd.

@bclyons12 I did code the dd to use shared concrete types for the IDSs that shared the same fields, and it worked. However I was unhappy with the resulting user API. I'll give this some more thought.