### PR TITLE
Bugfix/isequal

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -301,8 +301,6 @@ function Base.isequal(a::T1, b::T2; verbose::Bool=false) where {T1<:Union{IDS,ID
     return all_equal
 end
 
-Base.:(≈)(a::T1, b::T2) where {T1<:Union{IDS,IDSvector,Vector{IDS}},T2<:Union{IDS,IDSvector,Vector{IDS}}} = isapprox(a, b)
-
 function Base.isapprox(a::T1, b::T2; verbose::Bool=false, kw...) where {T1<:Union{IDS,IDSvector,Vector{IDS}},T2<:Union{IDS,IDSvector,Vector{IDS}}}
 
     comparable_fields = _extract_comparable_fields(a, b)

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -68,6 +68,10 @@ end
     @test dd1 == dd2
     @test dd1.core_sources == dd2.core_sources
 
+    dd2.equilibrium.time_slice[1].profiles_1d.volume[2] += 1e-15
+    @test !isequal(dd1, dd2)
+    @test isapprox(dd1, dd2)
+
     dd2.core_sources.time[] = 1.0
     @test !isequal(dd1, dd2; verbose=true);
     @test !isequal(dd1.core_sources, dd2.core_sources; verbose=true);
@@ -88,4 +92,6 @@ end
     isequal(dd1, dd2; verbose=true);
 
     isequal(dd1.equilibrium, dd2; verbose=true);
+
+
 end

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -100,7 +100,7 @@ end
     dd2.equilibrium.time_slice[1].profiles_1d.volume[2] += 1e-5
     @test !isapprox(dd1, dd2)
     @test dd1 ≉ dd2
-    @test isapprox(dd1, dd2; rtol=1e-4)
+    @test isapprox(dd1, dd2; atol=1e-4)
     dd2.equilibrium.time_slice[1].profiles_1d.volume[2] = dd1.equilibrium.time_slice[1].profiles_1d.volume[2]
 
 end

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -68,10 +68,6 @@ end
     @test dd1 == dd2
     @test dd1.core_sources == dd2.core_sources
 
-    dd2.equilibrium.time_slice[1].profiles_1d.volume[2] += 1e-15
-    @test !isequal(dd1, dd2)
-    @test isapprox(dd1, dd2)
-
     dd2.core_sources.time[] = 1.0
     @test !isequal(dd1, dd2; verbose=true);
     @test !isequal(dd1.core_sources, dd2.core_sources; verbose=true);
@@ -93,5 +89,18 @@ end
 
     isequal(dd1.equilibrium, dd2; verbose=true);
 
+    # isapprox test
+    dd2 = deepcopy(dd1)
+    dd2.equilibrium.time_slice[1].profiles_1d.volume[2] += 1e-13
+    @test !isequal(dd1, dd2)
+    @test isapprox(dd1, dd2)
+    @test dd1 ≈ dd2
+    dd2.equilibrium.time_slice[1].profiles_1d.volume[2] = dd1.equilibrium.time_slice[1].profiles_1d.volume[2]
+
+    dd2.equilibrium.time_slice[1].profiles_1d.volume[2] += 1e-5
+    @test !isapprox(dd1, dd2)
+    @test dd1 ≉ dd2
+    @test isapprox(dd1, dd2; rtol=1e-4)
+    dd2.equilibrium.time_slice[1].profiles_1d.volume[2] = dd1.equilibrium.time_slice[1].profiles_1d.volume[2]
 
 end


### PR DESCRIPTION
### Summary
- The bug in `isequal` is fixed by using `getproperty`, instead of `getfield`
- A new `isapprox` function is implemented to compare two IDS with some tolerance. @bclyons12 @orso82 

### Example
```julia
dd2 = deepcopy(dd1)
dd2.equilibrium.time_slice[1].profiles_1d.volume[2] += 1e-13
isequal(dd1, dd2) # return false
isapprox(dd1, dd2) # return true
dd1 ≈ dd2 # return true
isapprox(dd1, dd2; atol=1e-14) # return false
```