### PR TITLE
Improve TTFX of `deepcopy` and `fill!`

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -313,7 +313,7 @@ function Base.getproperty(@nospecialize(ids::IDS), field::Symbol, @nospecialize(
         valid = true
 
     elseif !isfrozen(ids)
-        # check 
+        # check
         valid = exec_expression_with_ancestor_args(ids, field; throw_on_missing=false)
     end
 
@@ -713,62 +713,7 @@ function Base.fill!(@nospecialize(IDS_new::Union{IDS,IDSvector}), @nospecialize(
     return IDS_new
 end
 
-#= ===== =#
-#  fill!  #
-#= ===== =#
-"""
-    Base.fill!(@nospecialize(ids_new::T1), @nospecialize(ids::T2)) where {T1<:IDS, T2<:IDS}
 
-Recursively fills `ids_new` from `ids`
-
-NOTE: in fill! the leaves of the strucutre are a deepcopy of the original
-
-NOTE: `ids_new` and `ids` don't have to be of the same parametric type.
-In other words, this can be used to copy data from a IDS{Float64} to a IDS{Real} or similar
-For this to work one must define a function
-`Base.fill!(@nospecialize(ids_new::IDS{T1}), @nospecialize(ids::IDS{T2}), field::Symbol) where {T1<:???, T2<:???}`
-"""
-function Base.fill!(@nospecialize(ids_new::T1), @nospecialize(ids::T2)) where {T1<:IDS,T2<:IDS}
-    filled = getfield(ids, :_filled)
-    for field in fieldnames(typeof(ids))
-        if hasfield(typeof(filled), field) && getfield(filled, field)
-            if fieldtype_typeof(ids, field) <: IDS
-                fill!(getfield(ids_new, field), getfield(ids, field))
-                add_filled(ids_new, field)
-            elseif fieldtype_typeof(ids, field) <: IDSvector
-                if !isempty(getfield(ids, field))
-                    fill!(getfield(ids_new, field), getfield(ids, field))
-                end
-            else
-                fill!(ids_new, ids, field)
-            end
-        end
-    end
-    return ids_new
-end
-
-function Base.fill!(@nospecialize(ids_new::T1), @nospecialize(ids::T2)) where {T1<:IDSvector,T2<:IDSvector}
-    resize!(ids_new, length(ids))
-    map(x -> fill!(x...), zip(ids_new, ids))
-    return ids_new
-end
-
-# fill for the same type
-function Base.fill!(@nospecialize(ids_new::IDS{T}), @nospecialize(ids::IDS{T}), field::Symbol) where {T<:Real}
-    value = getfield(ids, field)
-    return _setproperty!(ids_new, field, deepcopy(value), internal_cocos)
-end
-
-# fill between different types
-function Base.fill!(@nospecialize(ids_new::IDS{T1}), @nospecialize(ids::IDS{T2}), field::Symbol) where {T1<:Real,T2<:Real}
-    value = getfield(ids, field)
-    if field == :time || !(eltype(value) <: T2)
-        _setproperty!(ids_new, field, deepcopy(value), internal_cocos)
-    else
-        _setproperty!(ids_new, field, T1.(value), internal_cocos)
-    end
-    return nothing
-end
 
 #= ========= =#
 #  IDSvector  #

--- a/src/data.jl
+++ b/src/data.jl
@@ -617,7 +617,11 @@ push!(document[:Base], :setproperty!)
 #= ======== =#
 @inline function Base.deepcopy(@nospecialize(ids::Union{IDS,IDSvector}))
     # using fill! is much more efficient than going via Base.deepcopy_internal()
-    return fill!(typeof(ids)(), ids)
+    if ids isa IDS
+        return fill!(typeof(ids)(), ids)
+    else # IDSvector
+        return fill!(resize!(typeof(ids)(),length(ids)), ids)
+    end
 end
 
 @inline function Base.deepcopy(ids::DD)

--- a/src/data.jl
+++ b/src/data.jl
@@ -690,17 +690,8 @@ function Base.fill!(@nospecialize(IDS_new::Union{IDS,IDSvector}), @nospecialize(
                         end
                     end
                 else
-                    # Handle basic fields
-                    if eltype(ids_new) === eltype(ids)
-                        _setproperty!(ids_new, field, deepcopy(getfield(ids, field)), internal_cocos)
-                    else
-                        value = getfield(ids, field)
-                        if field === :time || !(eltype(value) <: eltype(ids))
-                            _setproperty!(ids_new, field, deepcopy(value), internal_cocos)
-                        else
-                            _setproperty!(ids_new, field, eltype(ids_new).(value), internal_cocos)
-                        end
-                    end
+                    # call appropriate dispatch of fill!
+                    fill!(ids_new, ids, field)
                 end
             end
         end

--- a/src/data.jl
+++ b/src/data.jl
@@ -709,7 +709,22 @@ function Base.fill!(@nospecialize(IDS_new::Union{IDS,IDSvector}), @nospecialize(
     return IDS_new
 end
 
+# fill for the same type
+function Base.fill!(@nospecialize(ids_new::IDS{T}), @nospecialize(ids::IDS{T}), field::Symbol) where {T<:Real}
+    value = getfield(ids, field)
+    return _setproperty!(ids_new, field, deepcopy(value), internal_cocos)
+end
 
+# fill between different types
+function Base.fill!(@nospecialize(ids_new::IDS{T1}), @nospecialize(ids::IDS{T2}), field::Symbol) where {T1<:Real,T2<:Real}
+    value = getfield(ids, field)
+    if field == :time || !(eltype(value) <: T2)
+        _setproperty!(ids_new, field, deepcopy(value), internal_cocos)
+    else
+        _setproperty!(ids_new, field, T1.(value), internal_cocos)
+    end
+    return nothing
+end
 
 #= ========= =#
 #  IDSvector  #

--- a/src/data.jl
+++ b/src/data.jl
@@ -627,22 +627,16 @@ end
     setfield!(ids_new, :_aux, deepcopy(getfield(ids, :_aux)))
     return ids_new
 end
-
 """
     Base.fill!(@nospecialize(IDS_new::Union{IDS,IDSvector}), @nospecialize(IDS_ori::Union{IDS,IDSvector}))
 
 fills `IDS_new` from `IDS_ori` using a stack-based approach, instead of recursion
 
-# Details
-- Performs a deep copy of leaf values
-- Makes appropriate type conversions when parametric types differ
-- Handles both `IDS_ori` and `IDSvector` types
-
-# Notes
+### Notes
 - `IDS_new` and `IDS_ori` must have matching wrapper types but can have different parametric types
-- Type conversions are automatically performed when copying from e.g., `IDS_ori{Float64}` to `IDS_ori{Real}`
-- Special handling is provided for time fields to ensure proper conversion
-
+- In other words, this can be used to copy data from a IDS{Float64} to a IDS{Real} or similar
+- For this to work one must define a function:
+ `Base.fill!(@nospecialize(IDS_new::IDS{T1}), @nospecialize(IDS_ori::IDS{T2}), field::Symbol) where {T1<:???, T2<:???}`
 """
 function Base.fill!(@nospecialize(IDS_new::Union{IDS,IDSvector}), @nospecialize(IDS_ori::Union{IDS,IDSvector}))
     # Check type structure (comparing only wrapper, not full type)


### PR DESCRIPTION
# Replace recursive `fill!` with stack-based approach
- Note: `deepcopy` uses `fill!`

## Issue
The original implementation of `deepcopy` and `fill!` used a recursive approach, leading to excessive compilation times on first execution. This created a significant bottleneck when initializing data structures for the first time.

## Solution
This PR replaces the recursive implementation with a stack-based approach, dramatically reducing compilation time without sacrificing functionality.

## TTFX Performance Comparison of `deepcopy`  for `dd`
The benchmark was performed on the `sample/omas_sample.json` dataset using simple `deepcopy` operations.
| Metric | Original (Recursive) | New (Stack-based) | Improvement |
|--------|----------------------|-------------------|-------------|
| Time | 288.87 seconds | 15.88 seconds | 18.2x faster |
| Allocations | 1.36G | 196.70M | 6.9x fewer |
| Memory | 66.27 GiB | 9.88 GiB | 6.7x less |
| Compilation % | 100.00 % | 99.96% | Similar |

## Notes
- While there is a small runtime performance penalty due to stack management overhead, the enormous compilation time improvement far outweighs this minor drawback.
- This branch is based on `v5.0.1` instead of master since the current master branch fails testing. 
- All tests pass with this implementation.

