### PR TITLE
Improve/f2p name and printnode

### DIFF
--- a/src/f2.jl
+++ b/src/f2.jl
@@ -198,6 +198,10 @@ end
     return reverse!(split(replace(ulocation(ids), "[:]" => ".0"), "."))
 end
 
+@inline function f2p_name(@nospecialize(ids::IDSvector), ::Nothing)
+    return ("",)
+end
+
 @inline function f2p_name(@nospecialize(ids::IDSvectorElement), @nospecialize(parent::IDSvector))
     return (string(index(ids)),)
 end

--- a/src/f2.jl
+++ b/src/f2.jl
@@ -202,6 +202,10 @@ end
     return ("",)
 end
 
+@inline function f2p_name(@nospecialize(ids::IDSvectorElement), ::Nothing)
+    return ("",)
+end
+
 @inline function f2p_name(@nospecialize(ids::IDSvectorElement), @nospecialize(parent::IDSvector))
     return (string(index(ids)),)
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -131,6 +131,22 @@ function AbstractTrees.printnode(io::IO, node_value::IMASnodeRepr)
     end
 end
 
+function Base.show(io::IO, @nospecialize(ids_arr::AbstractArray{<:IDS}); maxdepth::Int=1000, kwargs...)
+    for (i, ids) in enumerate(ids_arr)
+        print(io,"\n"*"="^15*" Item #$(i) "*"="^15*"\n")
+        AbstractTrees.print_tree(io, ids; maxdepth, kwargs...)
+    end
+    return
+end
+
+function Base.show(io::IO, @nospecialize(ids_arr::AbstractArray{<:IDSvector}); maxdepth::Int=1000, kwargs...)
+    for (i, ids) in enumerate(ids_arr)
+        print(io,"\n"*"="^15*" Item #$(i) "*"="^15*"\n")
+        AbstractTrees.print_tree(io, ids; maxdepth, kwargs...)
+    end
+    return
+end
+
 function Base.show(io::IO, @nospecialize(ids::Union{IDS,IDSvector}); maxdepth::Int=1000, kwargs...)
     return AbstractTrees.print_tree(io, ids; maxdepth, kwargs...)
 end
@@ -146,6 +162,14 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", ids::DD; maxdepth::Int=1, kwargs...) # only depth 1 for dd
     return show(io, ids; maxdepth, kwargs...)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", @nospecialize(ids_arr::AbstractArray{<:IDS}); maxdepth::Int=1000, kwargs...)
+    return show(io, ids_arr; maxdepth, kwargs...)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", @nospecialize(ids_arr::AbstractArray{<:IDSvector}); maxdepth::Int=1000, kwargs...)
+    return show(io, ids_arr; maxdepth, kwargs...)
 end
 
 # show function for inline prints

--- a/src/show.jl
+++ b/src/show.jl
@@ -45,7 +45,7 @@ function AbstractTrees.printnode(io::IO, @nospecialize(ids::IDS))
 end
 
 function AbstractTrees.printnode(io::IO, @nospecialize(ids::IDSvector))
-    return printstyled(io, f2p_name(parent(ids))[end]; bold=true)
+    return printstyled(io, f2p_name(ids)[1]; bold=true)
 end
 
 function AbstractTrees.printnode(io::IO, node_value::IMASnodeRepr)

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -109,8 +109,9 @@ end
     # Check if the dd variable is defined before the test
     @test isdefined(Main, :dd) || (dd = IMASdd.hdf2imas(joinpath(dirname(@__DIR__), "sample", "omas_sample.h5")))
 
-    buf = IOBuffer()
+    @test_nowarn show(stdout, MIME("text/plain"), dd.equilibrium.time_slice[1].profiles_2d)
+    @test_nowarn show(stdout, MIME("text/plain"), deepcopy(dd.equilibrium.time_slice[1].profiles_2d))
 
-    @test_nowarn show(buf, MIME("text/plain"), dd.equilibrium.time_slice[1].profiles_2d)
-    @test_nowarn show(buf, MIME("text/plain"), deepcopy(dd.equilibrium.time_slice[1].profiles_2d))
+    @test_nowarn show(stdout, MIME("text/plain"), dd.equilibrium.time_slice[1].profiles_2d[1])
+    @test_nowarn show(stdout, MIME("text/plain"), deepcopy(dd.equilibrium.time_slice[1].profiles_2d[1]))
 end

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -106,8 +106,7 @@ end
 end
 
 @testset "stdout show IO" begin
-    # Check if the dd variable is defined before the test
-    @test isdefined(Main, :dd) || (dd = IMASdd.hdf2imas(joinpath(dirname(@__DIR__), "sample", "omas_sample.h5")))
+    dd = IMASdd.hdf2imas(joinpath(dirname(@__DIR__), "sample", "omas_sample.h5"));
 
     @test_nowarn show(stdout, MIME("text/plain"), dd.equilibrium.time_slice[1].profiles_2d)
     @test_nowarn show(stdout, MIME("text/plain"), deepcopy(dd.equilibrium.time_slice[1].profiles_2d))

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -104,3 +104,13 @@ end
     dd2.equilibrium.time_slice[1].profiles_1d.volume[2] = dd1.equilibrium.time_slice[1].profiles_1d.volume[2]
 
 end
+
+@testset "stdout show IO" begin
+    # Check if the dd variable is defined before the test
+    @test isdefined(Main, :dd) || (dd = IMASdd.hdf2imas(joinpath(dirname(@__DIR__), "sample", "omas_sample.h5")))
+
+    buf = IOBuffer()
+
+    @test_nowarn show(buf, MIME("text/plain"), dd.equilibrium.time_slice[1].profiles_2d)
+    @test_nowarn show(buf, MIME("text/plain"), deepcopy(dd.equilibrium.time_slice[1].profiles_2d))
+end


### PR DESCRIPTION
## Summary
This PR resolves an issue with the `printnode` function that previously failed when processing `IDSvector` instances without a parent. This situation could occur after using `deepcopy` on an `IDS` object. Additionally, the PR enhances the display consistency of IDSvector objects to match their common representation (from higher-IDS) more closely.

## Changes
- Add `f2p_name` to properly handle IDSvector instances that lack a parent reference
- Improved the display consistency of IDSvector objects in the node tree output

## Example
![bitmap](https://github.com/user-attachments/assets/5d65f14d-97b6-40bd-af1c-95d10e353e6c)
