### PR TITLE
Properly parse complex values in dict2imas

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -239,7 +239,16 @@ function dict2imas(
                     if tp_ndims(target_type) > 1
                         value = row_col_major_switch(reduce(hcat, value))
                     end
-                    value = convert(target_type, value)
+                    if eltype(target_type) <: Complex
+                        CT = eltype(target_type)
+                        value = map(val -> CT(val["re"], val["im"]), value)
+                    end
+                    if !(value isa target_type)
+                        value = convert(target_type, value)
+                    end
+                end
+                if target_type <: Complex
+                    value = target_type(value["re"], value["im"])
                 end
                 # Handle special case for dictionaries saved as strings
                 if typeof(value) <: Dict && target_type <: String


### PR DESCRIPTION
JSON saves complex numbers in little dictionaries. For example:
```
julia> A = (1.0+1.0im)*ones(2,2)
2×2 Matrix{ComplexF64}:
 1.0+1.0im  1.0+1.0im
 1.0+1.0im  1.0+1.0im

julia> B = JSON.json(A)
"[[{\"re\":1.0,\"im\":1.0},{\"re\":1.0,\"im\":1.0}],[{\"re\":1.0,\"im\":1.0},{\"re\":1.0,\"im\":1.0}]]"

julia> C = JSON.parse(B)
2-element Vector{Any}:
 Any[Dict{String, Any}("re" => 1.0, "im" => 1.0), Dict{String, Any}("re" => 1.0, "im" => 1.0)]
 Any[Dict{String, Any}("re" => 1.0, "im" => 1.0), Dict{String, Any}("re" => 1.0, "im" => 1.0)]

julia> reduce(hcat, C)
2×2 Matrix{Dict{String, Any}}:
 Dict("re"=>1.0, "im"=>1.0)  Dict("re"=>1.0, "im"=>1.0)
 Dict("re"=>1.0, "im"=>1.0)  Dict("re"=>1.0, "im"=>1.0)
```

This processes those dictionaries back into complex numbers.

Fixes https://github.com/ProjectTorreyPines/IMASdd.jl/issues/68 so it works for complex arrays, but has not been tested for single complex numbers. I'm not sure if that exists anywhere in the dd.