### PR TITLE
Fix complex number array deserialization from JSON (fixes issue #68)

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -241,9 +241,11 @@ function dict2imas(
                     end
                     if eltype(target_type) <: Complex
                         value = eltype(target_type).(getindex.(value, "re"), getindex.(value, "im"))
-                    else
+                    elseif !(value isa target_type)
                         value = convert(target_type, value)
                     end
+                elseif target_type <: Complex
+                    value = target_type(value["re"], value["im"])
                 end
                 # Handle special case for dictionaries saved as strings
                 if typeof(value) <: Dict && target_type <: String

--- a/src/io.jl
+++ b/src/io.jl
@@ -239,7 +239,11 @@ function dict2imas(
                     if tp_ndims(target_type) > 1
                         value = row_col_major_switch(reduce(hcat, value))
                     end
-                    value = convert(target_type, value)
+                    if eltype(target_type) <: Complex
+                        value = eltype(target_type).(getindex.(value, "re"), getindex.(value, "im"))
+                    else
+                        value = convert(target_type, value)
+                    end
                 end
                 # Handle special case for dictionaries saved as strings
                 if typeof(value) <: Dict && target_type <: String

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -123,7 +123,7 @@ end
     resize!(dd.gyrokinetics_local.linear.wavevector[1].eigenmode,1)
     dd.gyrokinetics_local.linear.wavevector[1].eigenmode[1].angle_pol = 0:2π/11:2π
     dd.gyrokinetics_local.linear.wavevector[1].eigenmode[1].time_norm = [1.0]
-    dd.gyrokinetics_local.linear.wavevector[1].eigenmode[1].fields.a_field_parallel_perturbed_norm = (1.0+1.0im)*ones(10,2)
+    dd.gyrokinetics_local.linear.wavevector[1].eigenmode[1].fields.a_field_parallel_perturbed_norm = (1.0+2.0im)*rand(10,2)
 
     mktempdir() do folder
         @show folder

--- a/test/runtests_io.jl
+++ b/test/runtests_io.jl
@@ -116,3 +116,20 @@ end
     @test_nowarn show(stdout, MIME("text/plain"), dd.equilibrium.time_slice[1].profiles_2d[1])
     @test_nowarn show(stdout, MIME("text/plain"), deepcopy(dd.equilibrium.time_slice[1].profiles_2d[1]))
 end
+
+@testset "JSON IO with complex numbers" begin
+    dd = IMASdd.dd()
+    resize!(dd.gyrokinetics_local.linear.wavevector,1)
+    resize!(dd.gyrokinetics_local.linear.wavevector[1].eigenmode,1)
+    dd.gyrokinetics_local.linear.wavevector[1].eigenmode[1].angle_pol = 0:2π/11:2π
+    dd.gyrokinetics_local.linear.wavevector[1].eigenmode[1].time_norm = [1.0]
+    dd.gyrokinetics_local.linear.wavevector[1].eigenmode[1].fields.a_field_parallel_perturbed_norm = (1.0+1.0im)*ones(10,2)
+
+    mktempdir() do folder
+        @show folder
+        IMASdd.imas2json(dd, joinpath(folder, "dd.json"))
+        dd1 = IMASdd.json2imas(joinpath(folder, "dd.json"))
+
+        @test dd == dd1
+    end
+end


### PR DESCRIPTION
Fixes Issue #68:
Resolves deserialization error when loading complex number arrays from JSON files.

**Problem:**
- Complex arrays like `(1.0+ 2.0im)*ones(10,2)` were correctly serialized to JSON as dictionaries with `{"re": 1.0, "im": 2.0}` format
- Current `dict2imas` fails to convert this dictionary to a complex number, as no proper method is defined

**Solution:**
- Added a manual conversion inside `dict2imas` when `eltype(target_type) <: Complex`
- A dedicated test is added to `runtests_io.jl`

Issue #68 can be closed if this PR is merged.