### PR TITLE
Replace `Val` dispatch in `get_expressions` with separate functions

### DIFF
--- a/test/runtests_expressions.jl
+++ b/test/runtests_expressions.jl
@@ -24,7 +24,6 @@ otexp["equilibrium.time_slice[:].time"] =
     (; equilibrium, time_slice_index, _...) -> equilibrium.time[time_slice_index]
 
 @testset "expressions" begin
-    @test isempty(IMASdd.get_expressions(Val{:bla}))
 
     ne0 = 1E20
     Te0 = 1E3

--- a/test/test_expressions_dicts.jl
+++ b/test/test_expressions_dicts.jl
@@ -1,11 +1,7 @@
-function IMASdd.get_expressions(::Type{Val{:dynamic}})
-    return dynamic_expressions
-end
+# Register expressions in the absence of IMAS.jl
 
 const dynamic_expressions = dyexp = Dict{String,Function}()
-
-function IMASdd.get_expressions(::Type{Val{:onetime}})
-    return onetime_expressions
-end
+IMASdd.set_dynamic_expressions(dynamic_expressions)
 
 const onetime_expressions = otexp = Dict{String,Function}()
+IMASdd.set_onetime_expressions(onetime_expressions)


### PR DESCRIPTION
This patch replaces the `Val{:symbol}` dispatch in
`IMASdd.get_expressions` with `get_(dynamic|onetime)_expressions`.
Instead of defining new methods for `get_expressions` IMAS.jl will
explicitly register its global data structure using
`IMASdd.set_(dynamic|onetime)_expressions`.

The benefit of this restructure is that compilation of IMASdd becomes
independent of methods defined in IMAS. Before, after loading IMAS, a
lot of code in IMASdd had to be recompiled to take the new methods into
account.

Before:
```
julia> using IMASdd

julia> @time @eval IMASdd.dd();
  0.004902 seconds (20.73 k allocations: 864.656 KiB, 34.05% compilation time)

julia> using IMAS

julia> @time @eval IMAS.dd();
  7.673864 seconds (25.65 M allocations: 1.304 GiB, 3.21% gc time, 99.97% compilation time: 100% of which was recompilation)
```

After:
```
julia> using IMASdd

julia> @time @eval IMASdd.dd();
  0.002903 seconds (20.73 k allocations: 864.656 KiB, 55.30% compilation time)

julia> using IMAS

julia> @time @eval IMAS.dd();
  0.001035 seconds (20.69 k allocations: 863.375 KiB)
```
