### PR TITLE
(fix): pass matrix version and arch in CI

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
 
       - uses: julia-actions/cache@v2
 


### PR DESCRIPTION
## Summary
Fix CI to actually test each Julia version declared in the matrix. 
 Previously even CI with `v1.11` label actually ran on the latest release (1.12) due to the bug.

