### PR TITLE
Look up IDS metadata by type, not by location string

### DIFF
--- a/src/cocos.jl
+++ b/src/cocos.jl
@@ -48,7 +48,8 @@ Return Vector of strings with cocos_transform for a given IDS location
   - other strings, defining the cocos transformations as per the `CoordinateConventions.jl` package
 """
 function cocos_transform(@nospecialize(ids::IDS), field::Symbol)
-    cocos_transform(ulocation(ids, field))
+    # By type, not by location string — see `units(::IDS, ::Symbol)`.
+    return info(ids, field).cocos_transform
 end
 
 export cocos_transform

--- a/src/data.jl
+++ b/src/data.jl
@@ -93,7 +93,11 @@ end
 Return string with units for a given IDS field
 """
 @maybe_nospecializeinfer function units(@nospecialize(ids::IDS), field::Symbol)
-    return units(ulocation(ids, field))
+    # Look the field up by type, not by universal-location string. The string
+    # path resolves the struct name inside IMASdd, which fails for IDSs owned
+    # by a satellite data dictionary (`IFEdd.summary__target`, ...) even though
+    # they are registered in `_all_info`.
+    return info(ids, field).units
 end
 
 export units

--- a/src/data.jl
+++ b/src/data.jl
@@ -93,10 +93,8 @@ end
 Return string with units for a given IDS field
 """
 @maybe_nospecializeinfer function units(@nospecialize(ids::IDS), field::Symbol)
-    # Look the field up by type, not by universal-location string. The string
-    # path resolves the struct name inside IMASdd, which fails for IDSs owned
-    # by a satellite data dictionary (`IFEdd.summary__target`, ...) even though
-    # they are registered in `_all_info`.
+    # By type, not by location string: the string path resolves the struct name
+    # inside IMASdd, so it cannot see IDSs owned by a satellite dd.
     return info(ids, field).units
 end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -133,7 +133,7 @@ getproperty but with handling of `freeze` and `strict` logic
 """
 @maybe_nospecializeinfer function get_frozen_strict_property(@nospecialize(ids::IDS), field::Symbol; freeze::Bool, strict::Bool)
 
-    if strict && info(ulocation(ids, field)).extra
+    if strict && info(ids, field).extra
         return missing
     end
 
@@ -147,7 +147,7 @@ getproperty but with handling of `freeze` and `strict` logic
 end
 
 @maybe_nospecializeinfer function get_frozen_strict_property(@nospecialize(ids::DD), field::Symbol; freeze::Bool, strict::Bool)
-    if strict && info(ulocation(ids, field)).extra
+    if strict && info(ids, field).extra
         return missing
     end
     return getraw(ids, field)

--- a/test/runtests_satellite.jl
+++ b/test/runtests_satellite.jl
@@ -88,7 +88,8 @@ my_own_dd(; frozen::Bool=false) = my_own_dd{Float64}(; frozen)
 merge!(IMASdd._all_info, Dict(
     (my_own_dd, :my_own_ids) => IMASdd.Info(String[], "-", "STRUCTURE", "IDS owned by the satellite", true, String[]),
     (my_own_dd, :requirements) => IMASdd.Info(String[], "-", "STRUCTURE", "Reused IMASdd requirements IDS", true, String[]),
-    (my_own_ids, :my_value) => IMASdd.Info(String[], "-", "FLT_0D", "A satellite-only scalar", true, String[])
+    # real units (not "-"), so that `show` actually exercises the units lookup
+    (my_own_ids, :my_value) => IMASdd.Info(String[], "m", "FLT_0D", "A satellite-only scalar", true, String[])
 ))
 
 end # module FakeSatellite
@@ -113,6 +114,24 @@ end # module FakeSatellite
         @test eltype(FakeSatellite.my_own_dd{Float32}()) === Float32
         @test haskey(IMASdd._all_info, (FakeSatellite.my_own_dd, :my_own_ids))
         @test haskey(IMASdd._all_info, (FakeSatellite.my_own_ids, :my_value))
+    end
+
+    @testset "info / units / show on a satellite IDS" begin
+        # Regression: `units(::IDS, ::Symbol)` used to route through the
+        # universal-location string, which resolves the struct name inside
+        # IMASdd and therefore threw `UndefVarError: my_own_ids not defined in
+        # IMASdd` for every satellite-owned IDS. `show` calls it per field, so
+        # displaying a satellite container failed outright.
+        sat = FakeSatellite.my_own_dd{Float64}()
+        sat.my_own_ids.my_value = 3.0
+
+        @test IMASdd.info(sat.my_own_ids, :my_value).units == "m"
+        @test IMASdd.units(sat.my_own_ids, :my_value) == "m"
+
+        rendered = repr(MIME"text/plain"(), sat.my_own_ids)
+        @test occursin("my_value", rendered)
+        @test occursin("[m]", rendered)
+        @test !isempty(repr(MIME"text/plain"(), sat))
     end
 
     @testset "_resolve_concrete_type" begin

--- a/test/runtests_satellite.jl
+++ b/test/runtests_satellite.jl
@@ -86,6 +86,9 @@ my_own_dd(; frozen::Bool=false) = my_own_dd{Float64}(; frozen)
 # satellites register their own paths into the shared registry; keyed by our own
 # types, so this cannot collide with IMASdd's entries
 merge!(IMASdd._all_info, Dict(
+    # a satellite registers every field of its own container, `global_time`
+    # included — nothing falls back to `IMASdd.dd`'s entries
+    (my_own_dd, :global_time) => IMASdd.Info(String[], "s", "FLT_0D", "Generic global time", true, [""]),
     (my_own_dd, :my_own_ids) => IMASdd.Info(String[], "-", "STRUCTURE", "IDS owned by the satellite", true, String[]),
     (my_own_dd, :requirements) => IMASdd.Info(String[], "-", "STRUCTURE", "Reused IMASdd requirements IDS", true, String[]),
     # real units (not "-"), so that `show` actually exercises the units lookup
@@ -116,22 +119,30 @@ end # module FakeSatellite
         @test haskey(IMASdd._all_info, (FakeSatellite.my_own_ids, :my_value))
     end
 
-    @testset "info / units / show on a satellite IDS" begin
-        # Regression: `units(::IDS, ::Symbol)` used to route through the
-        # universal-location string, which resolves the struct name inside
-        # IMASdd and therefore threw `UndefVarError: my_own_ids not defined in
-        # IMASdd` for every satellite-owned IDS. `show` calls it per field, so
-        # displaying a satellite container failed outright.
+    @testset "metadata lookup on a satellite IDS" begin
+        # Regression: these all routed through the universal-location string,
+        # which resolves the struct name inside IMASdd and therefore threw
+        # `UndefVarError: my_own_ids not defined in IMASdd` for any
+        # satellite-owned IDS. Look them up by type instead.
         sat = FakeSatellite.my_own_dd{Float64}()
         sat.my_own_ids.my_value = 3.0
 
         @test IMASdd.info(sat.my_own_ids, :my_value).units == "m"
         @test IMASdd.units(sat.my_own_ids, :my_value) == "m"
+        @test IMASdd.cocos_transform(sat.my_own_ids, :my_value) == String[]
+        @test IMASdd.get_frozen_strict_property(sat.my_own_ids, :my_value;
+                                                freeze=false, strict=true) === missing
 
+        # `show` calls units per field, so display failed outright
         rendered = repr(MIME"text/plain"(), sat.my_own_ids)
         @test occursin("my_value", rendered)
         @test occursin("[m]", rendered)
         @test !isempty(repr(MIME"text/plain"(), sat))
+
+        # strict export walks every field through get_frozen_strict_property
+        path = joinpath(mktempdir(), "satellite.json")
+        IMASdd.imas2json(sat, path; strict=true)
+        @test isfile(path)
     end
 
     @testset "_resolve_concrete_type" begin


### PR DESCRIPTION
## Summary

A few functions took an IDS, built a universal-location string from it, and then resolved that string back to a type to look up `_all_info`. The round-trip works inside IMASdd, but it is slower, allocates more, and the string does not identify a type — `IMASdd.summary__code` and `IFEdd.summary__code` both map to `summary.code`, so satellite-owned IDSs either threw `UndefVarError` or silently resolved against IMASdd's entry.

`_all_info` is keyed by `(Type, Symbol)`. When the type is already in hand it is the exact key, so these now look it up directly — safer and faster.

## Changes

- `units(::IDS, ::Symbol)` → `info(ids, field).units`
- `cocos_transform(::IDS, ::Symbol)` → `info(ids, field).cocos_transform`
- `get_frozen_strict_property`, both methods → `info(ids, field).extra`

`units(::String)` and `cocos_transform(::String)` are unchanged — a location string is still the right input when no type is available.

Displaying a satellite container, and `imas2json(dd; strict=true)` on one, now work instead of throwing. Verified against the old route across a full `IMASdd.dd()` walk: identical results everywhere.

## Benchmark

| | before | after |
|---|---|---|
| metadata lookup | 891 ns, 8 alloc | 162 ns, 3 alloc |
| `imas2json(strict=true)` | 623 µs, 3533 alloc | 569 µs, 3196 alloc |
